### PR TITLE
fix(donation): clean up routes and remove missing imports

### DIFF
--- a/frontend/src/routes/routes.jsx
+++ b/frontend/src/routes/routes.jsx
@@ -19,8 +19,6 @@ const Donate = lazy(() => import("../pages/Donate"));
 const SignUp = lazy(() => import("../pages/Auth/SignUp"));
 const SignIn = lazy(() => import("../pages/Auth/SignIn"));
 const VerifyEmail = lazy(() => import("../pages/VerifyEmail"));
-const DonationFailed = lazy(() => import("../pages/DonationFailed"));
-const DonationSuccessful = lazy(() => import("../pages/DonationSuccessful"));
 const NotFound = lazy(() => import("../pages/NotFound"));
 const DonationResult = lazy(() => import("../pages/DonationResult"));
 


### PR DESCRIPTION
Removed the outdated imports of DonationFailed and DonationSuccessful from the routes file. The routes now only use the unified DonationResult page.
